### PR TITLE
fixed journal in DOI

### DIFF
--- a/lib/terrier/doi_data.rb
+++ b/lib/terrier/doi_data.rb
@@ -10,7 +10,7 @@ class Terrier::DoiData
     @citation_info = doi_citation_info
     {
       url: citation_info["URL"],
-      journal: citation_info["publisher"],
+      journal: citation_info["container-title"],
       title: citation_info["title"],
       authors: authors,
       publication_year: publication_year,

--- a/spec/doi_data_spec.rb
+++ b/spec/doi_data_spec.rb
@@ -17,7 +17,7 @@ describe Terrier::DoiData do
     end
 
     it "returns a collection containing the journal publisher" do
-      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:journal]).to eq('Springer Science + Business Media')
+      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:journal]).to eq('Int J Behav Nutr Phys Act')
     end
 
     it "returns a collection containing the journal title" do


### PR DESCRIPTION
The DOI lookup gives you the `journal` attribute, which is actually the *publisher* instead. To fix this you want to either rename it to *publisher* or use the correct attribute from the DOI lookup, which would be `container-title`. I went for the latter solution with this PR. :smile: 